### PR TITLE
Add set -e to prevent silent errors

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,5 @@
+set -e
+
 #Requires an installation of maven 2.x and Java 1.6 or higher
 
 # define the location of the install scipt


### PR DESCRIPTION
The previous setup just continued if installation failed, by adding "set -e" the bash script aborts with error code when the compilation does not work. 
