### PR TITLE
Changed version of WordNet in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,9 +57,9 @@
         <dependency>
             <groupId>com.github.cltl</groupId>
             <artifactId>WordnetTools</artifactId>
-            <version>master-SNAPSHOT</version>
-          <!--  <version>v3.0</version>
-            <scope>compile</scope>  -->
+            <!--  <version>master-SNAPSHOT</version>-->
+          <version>v3.0</version>
+            <!--  <scope>compile</scope>  -->
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>


### PR DESCRIPTION
The version of WordNet that is currently linked in the POM is not available through maven. I uncommented version 3.0 that can be automatically downloaded, so that I can use the scripts in https://github.com/cltl/vu-rm-pip3 to install this component.